### PR TITLE
Integrate PyO3

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "rust-analyzer.cargo.features": [
+        "pyo3"
+    ]
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -647,12 +647,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adab1eaa3408fb7f0c777a73e7465fd5656136fc93b670eb6df3c88c2c1344e3"
-
-[[package]]
 name = "inout"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1018,14 +1012,11 @@ version = "0.17.3"
 source = "git+https://github.com/PyO3/pyo3?rev=1d20f2a#1d20f2a5317585c13750e4433fe502dd25230775"
 dependencies = [
  "cfg-if",
- "indoc",
  "libc",
  "memoffset",
  "parking_lot",
  "pyo3-build-config",
  "pyo3-ffi",
- "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
@@ -1044,27 +1035,6 @@ source = "git+https://github.com/PyO3/pyo3?rev=1d20f2a#1d20f2a5317585c13750e4433
 dependencies = [
  "libc",
  "pyo3-build-config",
-]
-
-[[package]]
-name = "pyo3-macros"
-version = "0.17.3"
-source = "git+https://github.com/PyO3/pyo3?rev=1d20f2a#1d20f2a5317585c13750e4433fe502dd25230775"
-dependencies = [
- "proc-macro2",
- "pyo3-macros-backend",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "pyo3-macros-backend"
-version = "0.17.3"
-source = "git+https://github.com/PyO3/pyo3?rev=1d20f2a#1d20f2a5317585c13750e4433fe502dd25230775"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1742,12 +1712,6 @@ name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
-
-[[package]]
-name = "unindent"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58ee9362deb4a96cef4d437d1ad49cffc9b9e92d202b6995674e928ce684f112"
 
 [[package]]
 name = "universal-hash"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -647,6 +647,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adab1eaa3408fb7f0c777a73e7465fd5656136fc93b670eb6df3c88c2c1344e3"
+
+[[package]]
 name = "inout"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1012,11 +1018,14 @@ version = "0.17.3"
 source = "git+https://github.com/PyO3/pyo3?rev=1d20f2a#1d20f2a5317585c13750e4433fe502dd25230775"
 dependencies = [
  "cfg-if",
+ "indoc",
  "libc",
  "memoffset",
  "parking_lot",
  "pyo3-build-config",
  "pyo3-ffi",
+ "pyo3-macros",
+ "unindent",
 ]
 
 [[package]]
@@ -1035,6 +1044,27 @@ source = "git+https://github.com/PyO3/pyo3?rev=1d20f2a#1d20f2a5317585c13750e4433
 dependencies = [
  "libc",
  "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-macros"
+version = "0.17.3"
+source = "git+https://github.com/PyO3/pyo3?rev=1d20f2a#1d20f2a5317585c13750e4433fe502dd25230775"
+dependencies = [
+ "proc-macro2",
+ "pyo3-macros-backend",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pyo3-macros-backend"
+version = "0.17.3"
+source = "git+https://github.com/PyO3/pyo3?rev=1d20f2a#1d20f2a5317585c13750e4433fe502dd25230775"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1712,6 +1742,12 @@ name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
+name = "unindent"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58ee9362deb4a96cef4d437d1ad49cffc9b9e92d202b6995674e928ce684f112"
 
 [[package]]
 name = "universal-hash"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1015,8 +1015,7 @@ dependencies = [
 [[package]]
 name = "pyo3"
 version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "268be0c73583c183f2b14052337465768c07726936a260f480f0857cb95ba543"
+source = "git+https://github.com/PyO3/pyo3?rev=1d20f2a#1d20f2a5317585c13750e4433fe502dd25230775"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -1032,8 +1031,7 @@ dependencies = [
 [[package]]
 name = "pyo3-build-config"
 version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28fcd1e73f06ec85bf3280c48c67e731d8290ad3d730f8be9dc07946923005c8"
+source = "git+https://github.com/PyO3/pyo3?rev=1d20f2a#1d20f2a5317585c13750e4433fe502dd25230775"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -1042,8 +1040,7 @@ dependencies = [
 [[package]]
 name = "pyo3-ffi"
 version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f6cb136e222e49115b3c51c32792886defbfb0adead26a688142b346a0b9ffc"
+source = "git+https://github.com/PyO3/pyo3?rev=1d20f2a#1d20f2a5317585c13750e4433fe502dd25230775"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1052,8 +1049,7 @@ dependencies = [
 [[package]]
 name = "pyo3-macros"
 version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94144a1266e236b1c932682136dc35a9dee8d3589728f68130c7c3861ef96b28"
+source = "git+https://github.com/PyO3/pyo3?rev=1d20f2a#1d20f2a5317585c13750e4433fe502dd25230775"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1064,8 +1060,7 @@ dependencies = [
 [[package]]
 name = "pyo3-macros-backend"
 version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8df9be978a2d2f0cdebabb03206ed73b11314701a5bfe71b0d753b81997777f"
+source = "git+https://github.com/PyO3/pyo3?rev=1d20f2a#1d20f2a5317585c13750e4433fe502dd25230775"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -647,6 +647,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adab1eaa3408fb7f0c777a73e7465fd5656136fc93b670eb6df3c88c2c1344e3"
+
+[[package]]
 name = "inout"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -951,6 +957,7 @@ dependencies = [
  "borsh",
  "bytemuck",
  "lib-sokoban",
+ "pyo3",
  "solana-sdk",
  "spl-associated-token-account",
  "spl-noop",
@@ -1003,6 +1010,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "pyo3"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "268be0c73583c183f2b14052337465768c07726936a260f480f0857cb95ba543"
+dependencies = [
+ "cfg-if",
+ "indoc",
+ "libc",
+ "memoffset",
+ "parking_lot",
+ "pyo3-build-config",
+ "pyo3-ffi",
+ "pyo3-macros",
+ "unindent",
+]
+
+[[package]]
+name = "pyo3-build-config"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28fcd1e73f06ec85bf3280c48c67e731d8290ad3d730f8be9dc07946923005c8"
+dependencies = [
+ "once_cell",
+ "target-lexicon",
+]
+
+[[package]]
+name = "pyo3-ffi"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f6cb136e222e49115b3c51c32792886defbfb0adead26a688142b346a0b9ffc"
+dependencies = [
+ "libc",
+ "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-macros"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94144a1266e236b1c932682136dc35a9dee8d3589728f68130c7c3861ef96b28"
+dependencies = [
+ "proc-macro2",
+ "pyo3-macros-backend",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pyo3-macros-backend"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8df9be978a2d2f0cdebabb03206ed73b11314701a5bfe71b0d753b81997777f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1577,6 +1644,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-lexicon"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9410d0f6853b1d94f0e519fb95df60f29d2c1eff2d921ffdf01a4c8a3b54f12d"
+
+[[package]]
 name = "termcolor"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1674,6 +1747,12 @@ name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
+name = "unindent"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58ee9362deb4a96cef4d437d1ad49cffc9b9e92d202b6995674e928ce684f112"
 
 [[package]]
 name = "universal-hash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,9 @@ license = "MIT OR Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+pyo3 = ["dep:pyo3"]
+
 [dependencies]
 lib-sokoban = "0.1.13" 
 bytemuck = "1.11.0"
@@ -16,3 +19,4 @@ borsh = "0.9.3"
 spl-token = { version = "3.2.0", features = ["no-entrypoint"] }
 spl-associated-token-account = { version = "1.1.1", features = [ "no-entrypoint" ] }
 spl-noop = { version = "=0.1.0", features = [ "no-entrypoint" ] }
+pyo3 = { version = "0.17.3", features = ["extension-module", "abi3-py37"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,4 @@ borsh = "0.9.3"
 spl-token = { version = "3.2.0", features = ["no-entrypoint"] }
 spl-associated-token-account = { version = "1.1.1", features = [ "no-entrypoint" ] }
 spl-noop = { version = "=0.1.0", features = [ "no-entrypoint" ] }
-pyo3 = { version = "0.17.3", features = ["extension-module", "abi3-py37"], optional = true }
+pyo3 = { git = "https://github.com/PyO3/pyo3", rev = "1d20f2a", features = ["extension-module", "abi3-py37"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,4 @@ borsh = "0.9.3"
 spl-token = { version = "3.2.0", features = ["no-entrypoint"] }
 spl-associated-token-account = { version = "1.1.1", features = [ "no-entrypoint" ] }
 spl-noop = { version = "=0.1.0", features = [ "no-entrypoint" ] }
-pyo3 = { git = "https://github.com/PyO3/pyo3", rev = "1d20f2a", features = ["extension-module", "abi3-py37"], optional = true }
+pyo3 = { git = "https://github.com/PyO3/pyo3", rev = "1d20f2a", optional = true }

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -2,6 +2,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 #[cfg(feature = "pyo3")]
 use pyo3::prelude::*;
 
+/// Options for an order's self trade behavior.
 #[cfg_attr(feature = "pyo3", pyclass)]
 #[derive(BorshDeserialize, BorshSerialize, Copy, Clone, PartialEq, Eq, Debug)]
 pub enum SelfTradeBehavior {
@@ -16,6 +17,7 @@ pub enum SelfTradeBehavior {
     DecrementTake,
 }
 
+/// Options for an order's side.
 #[cfg_attr(feature = "pyo3", pyclass)]
 #[derive(BorshDeserialize, BorshSerialize, Copy, Clone, PartialEq, Eq, Debug)]
 pub enum Side {

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -2,6 +2,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 #[cfg(feature = "pyo3")]
 use pyo3::prelude::*;
 
+#[cfg_attr(feature = "pyo3", pyclass)]
 #[derive(BorshDeserialize, BorshSerialize, Copy, Clone, PartialEq, Eq, Debug)]
 pub enum SelfTradeBehavior {
     Abort,

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -1,4 +1,6 @@
 use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "pyo3")]
+use pyo3::prelude::*;
 
 #[derive(BorshDeserialize, BorshSerialize, Copy, Clone, PartialEq, Eq, Debug)]
 pub enum SelfTradeBehavior {
@@ -7,12 +9,23 @@ pub enum SelfTradeBehavior {
     DecrementTake,
 }
 
+#[cfg_attr(feature = "pyo3", pyclass)]
 #[derive(BorshDeserialize, BorshSerialize, Copy, Clone, PartialEq, Eq, Debug)]
 pub enum Side {
     Bid,
     Ask,
 }
 
+impl Side {
+    pub fn from_order_sequence_number(order_id: u64) -> Self {
+        match order_id.leading_zeros() {
+            0 => Side::Bid,
+            _ => Side::Ask,
+        }
+    }
+}
+
+#[cfg_attr(feature = "pyo3", pymethods)]
 impl Side {
     pub fn opposite(&self) -> Self {
         match *self {
@@ -21,10 +34,11 @@ impl Side {
         }
     }
 
-    pub fn from_order_sequence_number(order_id: u64) -> Self {
-        match order_id.leading_zeros() {
-            0 => Side::Bid,
-            _ => Side::Ask,
-        }
+    // cfg_attr doesn't work for staticmethod yet
+    #[cfg(feature = "pyo3")]
+    #[pyo3(name = "from_order_sequence_number")]
+    #[staticmethod]
+    pub fn py_from_order_sequence_number(order_id: u64) -> Self {
+        Self::from_order_sequence_number(order_id)
     }
 }

--- a/src/market.rs
+++ b/src/market.rs
@@ -7,17 +7,40 @@ use sokoban::node_allocator::{NodeAllocatorMap, OrderedNodeAllocatorMap, ZeroCop
 use sokoban::RedBlackTree;
 use solana_sdk::pubkey::Pubkey;
 
+#[cfg_attr(feature = "pyo3", pyclass(get_all, set_all))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct LadderOrder {
     pub price_in_ticks: u64,
     pub size_in_base_lots: u64,
 }
 
+#[cfg(feature = "pyo3")]
+#[pymethods]
+impl LadderOrder {
+    #[new]
+    pub fn new(price_in_ticks: u64, size_in_base_lots: u64) -> Self {
+        Self {
+            price_in_ticks,
+            size_in_base_lots,
+        }
+    }
+}
+
 /// Helpful struct for processing the order book state
+#[cfg_attr(feature = "pyo3", pyclass(get_all, set_all))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Ladder {
     pub bids: Vec<LadderOrder>,
     pub asks: Vec<LadderOrder>,
+}
+
+#[cfg(feature = "pyo3")]
+#[pymethods]
+impl Ladder {
+    #[new]
+    pub fn new(bids: Vec<LadderOrder>, asks: Vec<LadderOrder>) -> Self {
+        Self { bids, asks }
+    }
 }
 
 pub trait Market {
@@ -248,6 +271,24 @@ pub struct FIFOOrderId {
     /// The way to identify the side of the order is to check the leading bit of `order_id`.
     /// A leading bit of 0 indicates an ask, and a leading bit of 1 indicates a bid. See Side::from_order_id.
     pub order_sequence_number: u64,
+}
+
+#[cfg(feature = "pyo3")]
+#[pymethods]
+impl FIFOOrderId {
+    #[pyo3(name = "new_from_untyped")]
+    #[staticmethod]
+    pub fn py_new_from_untyped(
+        num_quote_ticks_per_base_unit: u64,
+        order_sequence_number: u64,
+    ) -> Self {
+        Self::new_from_untyped(num_quote_ticks_per_base_unit, order_sequence_number)
+    }
+
+    #[new]
+    pub fn py_new(num_quote_ticks_per_base_unit: u64, order_sequence_number: u64) -> Self {
+        Self::new(num_quote_ticks_per_base_unit, order_sequence_number)
+    }
 }
 
 impl FIFOOrderId {

--- a/src/market.rs
+++ b/src/market.rs
@@ -1,6 +1,8 @@
 use crate::enums::Side;
 use borsh::{BorshDeserialize, BorshSerialize};
 use bytemuck::{Pod, Zeroable};
+#[cfg(feature = "pyo3")]
+use pyo3::prelude::*;
 use sokoban::node_allocator::{NodeAllocatorMap, OrderedNodeAllocatorMap, ZeroCopy, SENTINEL};
 use sokoban::RedBlackTree;
 use solana_sdk::pubkey::Pubkey;
@@ -226,6 +228,7 @@ pub struct Seat {
 
 impl ZeroCopy for Seat {}
 
+#[cfg_attr(feature = "pyo3", pyclass(get_all, set_all))]
 #[repr(C)]
 #[derive(Eq, PartialEq, Debug, Default, Copy, Clone, Zeroable, Pod)]
 pub struct FIFOOrderId {


### PR DESCRIPTION
This adds PyO3 attributes for every type that gets used in phoenix-sdk. Two things to note:

1. There is more stuff to be added once pyo3 gets a new release #3 
2. This code doesn't create a Python library. That will happen in the SDK crate